### PR TITLE
feature/EODHP-392-update-application-hub-jh-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM jupyter/base-notebook:python-3.7.6
+
+USER root
+
+# prerequisites
+RUN DEBIAN_FRONTEND="noninteractive" apt-get -y update && \
+    apt-get -y install curl python3-pip ca-certificates unzip groff less tzdata keyboard-configuration
+
+# podman
+RUN echo "deb [trusted=yes] https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list && \
+    curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/Release.key | apt-key add - && \
+    apt-get -y update && apt-get -y install podman && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/bin/podman /usr/bin/docker # required by cwltool docker pull even if running with --podman
+
+# install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin
+
+# AWS CLI installation commands
+RUN	curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+	unzip awscliv2.zip && ./aws/install && \
+    rm -fr aws awscliv2.zip && \
+    pip3 install awscli-plugin-endpoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/base-notebook:python-3.7.6
+FROM jupyter/base-notebook:python-3.11
 
 USER root
 
@@ -20,6 +20,6 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 
 # AWS CLI installation commands
 RUN	curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-	unzip awscliv2.zip && ./aws/install && \
+    unzip awscliv2.zip && ./aws/install && \
     rm -fr aws awscliv2.zip && \
     pip3 install awscli-plugin-endpoint

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # EOEPCA Application Hub - Single User Image
+
+A single user image for running Jupyter Notebooks as part of the EOEPCA Application Hub. It is built on top of jupyter/base-notebook image.
+
+## Build
+
+```
+docker build public.ecr.aws/n1b3o1k2/apphub-singleuser:tag .
+docker push public.ecr.aws/n1b3o1k2/apphub-singleuser:tag
+```
+
+## Run
+
+```
+docker run --rm -p 8888:8888 public.ecr.aws/n1b3o1k2/apphub-singleuser:tag
+```


### PR DESCRIPTION
Cloned and owned https://github.com/EOEPCA/iat-jupyterlab to update to the latest base image of jupyter/base-notebook to python3.11. Deployed to public.ecr.aws/n1b3o1k2/apphub-singleuser.